### PR TITLE
upload and send media_group, cleaner

### DIFF
--- a/examples/upload_media_group.v
+++ b/examples/upload_media_group.v
@@ -10,40 +10,36 @@ struct App {
 fn (mut app App) send(result vt.Result) ! {
 	println('sending...')
 
-	// if you upload files, then use `upload` method,
-	// if you add http url or file_id, then use `add` method
-
-	mut media_group_http := vt.new_media_group[vt.InputMediaDocument]()
-	media_group_http.add(vt.InputMediaDocument.new(
-		media: 'https://raw.githubusercontent.com/tpn/pdfs/master/C%20Cheat%20Sheet%20(ashlyn-black_c-reference).pdf'
-	))
-	media_group_http.add(vt.InputMediaDocument.new(
-		media: 'https://raw.githubusercontent.com/tpn/pdfs/master/Compiler%20Design%20In%20C.pdf'
-	))
-	media_group_http.add(vt.InputMediaDocument.new(
-		media: 'https://raw.githubusercontent.com/tpn/pdfs/master/ChatGPT%20Cheat%20Sheet.pdf'
-	))
-
-	app.send_media_group[vt.InputMediaDocument](media_group_http,
+	mut mg := vt.new_media_group[vt.InputMediaDocument]()
+	mg.add(media: 'https://raw.githubusercontent.com/tpn/pdfs/master/C%20Cheat%20Sheet%20(ashlyn-black_c-reference).pdf')
+	mg.add(media: 'https://raw.githubusercontent.com/tpn/pdfs/master/Compiler%20Design%20In%20C.pdf')
+	mg.add(media: 'https://raw.githubusercontent.com/tpn/pdfs/master/ChatGPT%20Cheat%20Sheet.pdf')
+	app.send_media_group(
 		chat_id: result.update.message.chat.id
+		media: mg
 	)!
 
 	mut media_group := vt.new_media_group[vt.InputMediaDocument]()
-	thumbnail := vt.InputFile.new('./examples/1.jpg')!
-	media_group.upload(vt.InputMediaDocument.new(media: './VTelegram.svg', caption: 'logo'))!
-	media_group.upload(vt.InputMediaDocument.new(
-		media: './examples/1.pdf'
-		thumbnail: thumbnail
-		caption: 'pdf'
-	))!
+	doc1 := vt.InputFile.new('./VTelegram.svg')!
 
-	app.send_media_group[vt.InputMediaDocument](media_group,
+	media_group.add(
+		media: 'https://raw.githubusercontent.com/tpn/pdfs/master/A%20Compilation%20Target%20for%20Probabilistic%20Programming%20Languages%20-%202014%20(paige14).pdf'
+	)
+	media_group.add(
+		media: doc1
+	)
+	app.send_media_group(
 		chat_id: result.update.message.chat.id
+		media: media_group
 	)!
 
-	// media_group.add(
-	// 	vt.InputMediaDocument.new(media: 'https://raw.githubusercontent.com/vvo/gifify/master/22.gif')!
-	// )
+	mut mg_photo := vt.new_media_group[vt.InputMediaPhoto]()
+	jpg := vt.InputFile.new('./examples/1.jpg')!
+	mg_photo.add(media: jpg)
+	app.send_media_group(
+		chat_id: result.update.message.chat.id
+		media: mg_photo
+	)!
 }
 
 fn main() {

--- a/src/media_files.v
+++ b/src/media_files.v
@@ -22,7 +22,7 @@ pub fn InputFile.new(path string) !InputFile {
 	}
 }
 
-fn prepare_files[T](inputs []T) map[string][]http.FileData {
+fn prepare_files(inputs []InputFile) map[string][]http.FileData {
 	mut files := map[string][]http.FileData{}
 	for input in inputs {
 		files[input.file_name] << prepare_file(input)
@@ -30,7 +30,7 @@ fn prepare_files[T](inputs []T) map[string][]http.FileData {
 	return files
 }
 
-fn prepare_file[T](input T) http.FileData {
+fn prepare_file(input InputFile) http.FileData {
 	mime_type := mime.get_mime_type(input.file_name.all_after_last('.'))
 	return http.FileData{
 		filename: input.file_name

--- a/src/media_group.v
+++ b/src/media_group.v
@@ -1,7 +1,5 @@
 module vtelegram
 
-import os
-
 pub type InputMedia = InputMediaAnimation
 	| InputMediaAudio
 	| InputMediaDocument
@@ -11,14 +9,11 @@ pub type InputMedia = InputMediaAnimation
 // InputMediaPhoto Represents a photo to be sent.
 [params]
 pub struct InputMediaPhoto {
-mut:
-	file_name    string [json: '-']
-	file_content string [json: '-'; str: skip]
 pub mut:
 	// type Type of the result, must be photo
 	@type string
 	// media File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name. More information on Sending Files »
-	media string
+	media InputFileOrStringType
 	// caption Optional. Caption of the photo to be sent, 0-1024 characters after entities parsing
 	caption string
 	// parse_mode Optional. Mode for parsing entities in the photo caption. See formatting options for more details.
@@ -32,14 +27,11 @@ pub mut:
 // InputMediaVideo Represents a video to be sent.
 [params]
 pub struct InputMediaVideo {
-mut:
-	file_name    string [json: '-']
-	file_content string [json: '-'; str: skip]
 pub mut:
 	// type Type of the result, must be video
 	@type string
 	// media File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name. More information on Sending Files »
-	media string
+	media InputFileOrStringType
 	// thumbnail Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data.
 	// Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More information on Sending Files »
 	thumbnail InputFileOrStringType
@@ -64,14 +56,11 @@ pub mut:
 // InputMediaAnimation Represents an animation file (GIF or H.264/MPEG-4 AVC video without sound) to be sent.
 [params]
 pub struct InputMediaAnimation {
-mut:
-	file_name    string [json: '-']
-	file_content string [json: '-'; str: skip]
 pub mut:
 	// type Type of the result, must be animation
 	@type string
 	// media File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name. More information on Sending Files »
-	media string
+	media InputFileOrStringType
 	// thumbnail Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size.
 	// A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More information on Sending Files »
 	thumbnail InputFileOrStringType
@@ -94,14 +83,11 @@ pub mut:
 // InputMediaAudio Represents an audio file to be treated as music to be sent.
 [params]
 pub struct InputMediaAudio {
-mut:
-	file_name    string [json: '-']
-	file_content string [json: '-'; str: skip]
 pub mut:
 	// type Type of the result, must be audio
 	@type string
 	// media File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name. More information on Sending Files »
-	media string
+	media InputFileOrStringType
 	// thumbnail Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data.
 	// Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More information on Sending Files »
 	thumbnail InputFileOrStringType
@@ -122,14 +108,11 @@ pub mut:
 // InputMediaDocument Represents a general file to be sent.
 [params]
 pub struct InputMediaDocument {
-mut:
-	file_name    string [json: '-']
-	file_content string [json: '-'; str: skip]
 pub mut:
 	// type Type of the result, must be document
 	@type string
 	// media File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name. More information on Sending Files »
-	media string
+	media InputFileOrStringType
 	// thumbnail Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data.
 	// Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More information on Sending Files »
 	thumbnail InputFileOrStringType
@@ -169,47 +152,36 @@ pub fn InputMediaDocument.new(input InputMediaDocument) InputMediaDocument {
 }
 
 // new_media_group create media group of type you want (media group can be 1 type only).
-// Telegram will complain if you mix things - adding file_id with uploading or adding url-
-// Or use upload, or add with file_id, or add with http url
 [inline]
-pub fn new_media_group[T]() SendMediaGroup[T] {
-	return SendMediaGroup[T]{}
+pub fn new_media_group[T]() []T {
+	return []T{}
 }
 
-// add one media with file_id or url only
-pub fn (mut group SendMediaGroup[T]) add[T](input T) {
+pub fn (mut group []InputMediaDocument) add(input InputMediaDocument) {
 	mut a := input
-	$if T is InputMediaAnimation {
-		a.@type = 'animation'
-	} $else $if T is InputMediaAudio {
-		a.@type = 'audio'
-	} $else $if T is InputMediaPhoto {
-		a.@type = 'photo'
-	} $else $if T is InputMediaVideo {
-		a.@type = 'video'
-	} $else {
-		a.@type = 'document'
+	a.@type = 'document'
+	if a.thumbnail !is InputFile {
+		a.thumbnail = '' as string
 	}
-	a.thumbnail = '' as string
-	group.media << a
+	group << a
 }
-
-// upload one media from disk
-pub fn (mut group SendMediaGroup[T]) upload[T](input T) ! {
-	mut u := input
-	$if T is InputMediaAnimation {
-		u.@type = 'animation'
-	} $else $if T is InputMediaAudio {
-		u.@type = 'audio'
-	} $else $if T is InputMediaPhoto {
-		u.@type = 'photo'
-	} $else $if T is InputMediaVideo {
-		u.@type = 'video'
-	} $else {
-		u.@type = 'document'
-	}
-	u.file_name = os.file_name(input.media)
-	u.file_content = os.read_file(input.media)!
-	u.media = 'attach://${u.file_name}'
-	group.media << u
+pub fn (mut group []InputMediaAnimation) add(input InputMediaAnimation) {
+	mut a := input
+	a.@type = 'animation'
+	group << a
+}
+pub fn (mut group []InputMediaAudio) add(input InputMediaAudio) {
+	mut a := input
+	a.@type = 'audio'
+	group << a
+}
+pub fn (mut group []InputMediaPhoto) add(input InputMediaPhoto) {
+	mut a := input
+	a.@type = 'photo'
+	group << a
+}
+pub fn (mut group []InputMediaVideo) add(input InputMediaVideo) {
+	mut a := input
+	a.@type = 'video'
+	group << a
 }


### PR DESCRIPTION
only 1 method to add a media to group, `add`

```v
        mut mg := vt.new_media_group[vt.InputMediaDocument]()
	mg.add(media: 'https://URL')
	mg.add(media: 'https://URL')
	app.send_media_group(
		chat_id: result.update.message.chat.id
		media: mg
	)!

// if upload the files from disk:
        mut media_group := vt.new_media_group[vt.InputMediaDocument]()
	doc1 := vt.InputFile.new('./VTelegram.svg')!

	media_group.add(
		media: doc1
	)
	app.send_media_group(
		chat_id: result.update.message.chat.id
		media: media_group
	)!
```